### PR TITLE
adicionado sqlite3 por padrão

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ data/cache/*
 .history/
 .composer/
 .bash_history
+test.sqlite
+.idea
+.sqlite_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 FROM php:7.4-apache
 
 RUN apt-get update \
- && apt-get install -y git zlib1g-dev libzip-dev libicu-dev \
+ && apt-get install -y git zlib1g-dev libzip-dev libicu-dev sqlite3 libsqlite3-dev \
  && docker-php-ext-install zip intl \
  && a2enmod rewrite \
  && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf \


### PR DESCRIPTION
- melhorado arquivo Dockerfile para já trazer o serviço do sqlite3 instalado por padrão.

- adicionado ignore da ide PHPStorm e arquivos relacionados ao banco SQLite